### PR TITLE
Fix safe-area insets and accessibility for history nav button

### DIFF
--- a/app/components/chat-box-text/chat-box-text.tsx
+++ b/app/components/chat-box-text/chat-box-text.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { StyleSheet, Text, View, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 export interface ChatBoxTextProps {
   message: string;
@@ -17,32 +17,17 @@ export const ChatBoxText: React.FC<ChatBoxTextProps> = ({
 }) => {
   return (
     <View style={styles.container}>
-      <TouchableOpacity 
-        style={styles.historyButton}
-        onPress={onHistoryPress}
-        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-      >
-        <Ionicons 
-          name="time-outline" 
-          size={20} 
-          color="white" 
-        />
-      </TouchableOpacity>
       <View style={[styles.bubble, hasError && styles.errorBubble]}>
         <Text style={[styles.text, hasError && styles.errorText]}>
           {message}
         </Text>
         {hasError && (
-          <TouchableOpacity 
+          <TouchableOpacity
             style={styles.retryButton}
             onPress={onRetryPress}
             hitSlop={{ top: 5, bottom: 5, left: 5, right: 5 }}
           >
-            <Ionicons 
-              name="refresh" 
-              size={16} 
-              color="#FF6B35" 
-            />
+            <Ionicons name="refresh" size={16} color="#FF6B35" />
             <Text style={styles.retryText}>Retry</Text>
           </TouchableOpacity>
         )}
@@ -104,13 +89,5 @@ const styles = StyleSheet.create({
     color: "#FF6B35",
     marginLeft: 4,
     fontWeight: "500",
-  },
-  historyButton: {
-    alignSelf: "flex-end",
-    bottom: -8,
-    padding: 8,
-    borderRadius: 12,
-    backgroundColor: "black",
-    zIndex: 1,
   },
 });

--- a/app/components/drink-info-chat-box/drink-info-chat-box.tsx
+++ b/app/components/drink-info-chat-box/drink-info-chat-box.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 export interface DrinkInfoChatBoxProps {
-  onPress?: () => void;
+  text?: string;
 }
 
 export const DrinkInfoChatBox: React.FC<DrinkInfoChatBoxProps> = ({
-  onPress,
+  text = "Oto kilka propozycji, które dla Ciebie znalazłem. Mam nadzieję, że trafią w Twój gust!",
 }) => {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Text>
+      <Text style={styles.text}>{text}</Text>
     </View>
   );
 };

--- a/app/components/drinks-carousel/drinks-carousel.tsx
+++ b/app/components/drinks-carousel/drinks-carousel.tsx
@@ -1,221 +1,243 @@
 import { addToHistory, getDrinks } from "@/api.js";
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Dimensions,
-  ScrollView,
-  StyleSheet,
-  View
-} from "react-native";
+import { Dimensions, ScrollView, StyleSheet, View } from "react-native";
 import { Drink } from "../../types/drink";
 import { DrinkView } from "../drink-view/drink-view";
 import { RecommendDrinkView } from "../recommend-drink-view/recommend-drink-view";
 
-export const DrinksCarousel = ({ 
-  message, 
-  messageIndex, 
-  filters, 
-  onError 
-}: { 
-  message: string; 
-  messageIndex: number; 
+export const DrinksCarousel = ({
+  message,
+  messageIndex,
+  filters,
+  onError,
+}: {
+  message: string;
+  messageIndex: number;
   filters: { flavorProfile: string; power: string };
   onError?: (error: string) => void;
 }) => {
-    const windowWidth = Dimensions.get("window").width;
-    const [drinks, setDrinks] = useState<Drink[]>([]);
-    const [processedMessages, setProcessedMessages] = useState<Set<number>>(new Set());
-    const scrollViewRef = useRef<ScrollView>(null);
+  const windowWidth = Dimensions.get("window").width;
+  const [drinks, setDrinks] = useState<Drink[]>([]);
+  const [processedMessages, setProcessedMessages] = useState<Set<number>>(
+    new Set(),
+  );
+  const scrollViewRef = useRef<ScrollView>(null);
 
-    // Manual retry function
-    const retryFetch = () => {
-      fetchDrinks();
-    };
+  // Manual retry function
+  const retryFetch = () => {
+    fetchDrinks();
+  };
 
-    // Get Drinks
-    const fetchDrinks = async () => {
-      try {
-        // Add timeout handling
-        const timeout = new Promise((_, reject) => 
-          setTimeout(() => reject(new Error('Request timeout')), 15000)
-        );
-        
-        const response = await Promise.race([getDrinks(filters), timeout]);
-        const drinksData = response.drinks || response;
-        setDrinks(drinksData);
-        setMessagePagination(prev => ({
-          ...prev,
-          [messageIndex]: 0
-        }));
-        setTimeout(() => {
-          scrollViewRef.current?.scrollTo({ x: 0, y: 0, animated: false });
-        }, 100);
-      } catch (error) {
-        console.error('Error fetching drinks:', error);
-        setDrinks([]);
-        
-        // Handle specific error types
-        let errorMessage = 'Wystąpił nieznany błąd podczas pobierania drinków';
-        
-        if (error instanceof TypeError && error.message.includes('Failed to fetch')) {
-          errorMessage = 'Błąd sieci: Nie można połączyć z serwerem. Sprawdź połączenie z internetem.';
-        } else if (error instanceof Error && error.message.includes('Request timeout')) {
-          errorMessage = 'Błąd przekroczenia czasu: Serwer odpowiada zbyt wolno. Spróbuj ponownie.';
-        } else if (error instanceof Error && error.message.includes('ERR_CONNECTION_REFUSED')) {
-          errorMessage = 'Odrzucono połączenie: Serwer backend nie jest uruchomiony lub nie jest dostępny.';
-        } else if (error instanceof Error && error.message.includes('404')) {
-          console.log('Błąd 404 obrazu (oczekiwany):', error.message);
-          return;
-        } else if (typeof error === 'string' && error.includes('404')) {
-          console.log('Błąd 404 URL obrazu (oczekiwany):', error);
-          return;
-        }
-        
-        console.error(errorMessage);
-        onError?.(errorMessage);
+  // Get Drinks
+  const fetchDrinks = async () => {
+    try {
+      // Add timeout handling
+      const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("Request timeout")), 15000),
+      );
+
+      const response = await Promise.race([getDrinks(filters), timeout]);
+      const drinksData = response.drinks || response;
+      setDrinks(drinksData);
+      setMessagePagination((prev) => ({
+        ...prev,
+        [messageIndex]: 0,
+      }));
+      setTimeout(() => {
+        scrollViewRef.current?.scrollTo({ x: 0, y: 0, animated: false });
+      }, 100);
+    } catch (error) {
+      console.error("Error fetching drinks:", error);
+      setDrinks([]);
+
+      // Handle specific error types
+      let errorMessage = "Wystąpił nieznany błąd podczas pobierania drinków";
+
+      if (
+        error instanceof TypeError &&
+        error.message.includes("Failed to fetch")
+      ) {
+        errorMessage =
+          "Błąd sieci: Nie można połączyć z serwerem. Sprawdź połączenie z internetem.";
+      } else if (
+        error instanceof Error &&
+        error.message.includes("Request timeout")
+      ) {
+        errorMessage =
+          "Błąd przekroczenia czasu: Serwer odpowiada zbyt wolno. Spróbuj ponownie.";
+      } else if (
+        error instanceof Error &&
+        error.message.includes("ERR_CONNECTION_REFUSED")
+      ) {
+        errorMessage =
+          "Odrzucono połączenie: Serwer backend nie jest uruchomiony lub nie jest dostępny.";
+      } else if (error instanceof Error && error.message.includes("404")) {
+        console.log("Błąd 404 obrazu (oczekiwany):", error.message);
+        return;
+      } else if (typeof error === "string" && error.includes("404")) {
+        console.log("Błąd 404 URL obrazu (oczekiwany):", error);
+        return;
       }
+
+      console.error(errorMessage);
+      onError?.(errorMessage);
     }
-    
-    useEffect(() => {
-      fetchDrinks();
-    }, [filters, messageIndex]); 
-    
-    if (!message) return null;
-    
-    const [messagePagination, setMessagePagination] = useState<{[key: number]: number}>({});
-    
-    // Pagination
-    const handleScroll = (event: any) => {
-      const contentOffset = event.nativeEvent.contentOffset;
-      const viewSize = event.nativeEvent.layoutMeasurement;
-      const pageNum = Math.floor(contentOffset.x / viewSize.width + 0.5);
-      
-      const currentMessagePage = messagePagination[messageIndex] || 0;
-      if (currentMessagePage !== pageNum) {
-        setMessagePagination(prev => ({
-          ...prev,
-          [messageIndex]: pageNum
-        }));
-      }
-    };
-    
+  };
+
+  useEffect(() => {
+    fetchDrinks();
+  }, [filters, messageIndex]);
+
+  if (!message) return null;
+
+  const [messagePagination, setMessagePagination] = useState<{
+    [key: number]: number;
+  }>({});
+
+  // Pagination
+  const handleScroll = (event: any) => {
+    const contentOffset = event.nativeEvent.contentOffset;
+    const viewSize = event.nativeEvent.layoutMeasurement;
+    const pageNum = Math.floor(contentOffset.x / viewSize.width + 0.5);
+
     const currentMessagePage = messagePagination[messageIndex] || 0;
-    
-    // Apply filter if provided
-    const filteredDrinks = drinks.filter((drink: Drink) => {
-      const flavorMatch = !filters.flavorProfile || drink.flavor_profile === filters.flavorProfile;
-      const strengthMatch = !filters.power || drink.strength === filters.power;
-      return flavorMatch && strengthMatch;
-    });
+    if (currentMessagePage !== pageNum) {
+      setMessagePagination((prev) => ({
+        ...prev,
+        [messageIndex]: pageNum,
+      }));
+    }
+  };
 
-    // Add drinks to history with context
-    const addDrinksToHistory = async () => {
-      if (filteredDrinks && filteredDrinks.length > 0 && !processedMessages.has(messageIndex)) {
-        
-        setProcessedMessages((prev: Set<number>) => new Set([...prev, messageIndex]));
-        
-        for (const drink of filteredDrinks) {
-          try {
-            await addToHistory(drink);
-            console.log(`Drink "${drink.name}" added to history successfully`);
-          } catch (historyError) {
-            console.error(`Failed to add drink "${drink.name}" to history:`, historyError);
-          }
+  const currentMessagePage = messagePagination[messageIndex] || 0;
+
+  // Apply filter if provided
+  const filteredDrinks = drinks.filter((drink: Drink) => {
+    const flavorMatch =
+      !filters.flavorProfile || drink.flavor_profile === filters.flavorProfile;
+    const strengthMatch = !filters.power || drink.strength === filters.power;
+    return flavorMatch && strengthMatch;
+  });
+
+  // Add drinks to history with context
+  const addDrinksToHistory = async () => {
+    if (
+      filteredDrinks &&
+      filteredDrinks.length > 0 &&
+      !processedMessages.has(messageIndex)
+    ) {
+      setProcessedMessages(
+        (prev: Set<number>) => new Set([...prev, messageIndex]),
+      );
+
+      for (const drink of filteredDrinks) {
+        try {
+          await addToHistory(drink);
+          console.log(`Drink "${drink.name}" added to history successfully`);
+        } catch (historyError) {
+          console.error(
+            `Failed to add drink "${drink.name}" to history:`,
+            historyError,
+          );
         }
       }
     }
-    
-    // Add drinks to history when drinks are loaded (not when filtered)
-    useEffect(() => {
-      if (drinks.length > 0 && !processedMessages.has(messageIndex)) {
-        addDrinksToHistory();
-      }
-    }, [drinks, messageIndex]);
-    
-    // Horizontal Scroll View
-    return (
-      <View style={styles.container}>
-        <ScrollView 
-          ref={scrollViewRef}
-          horizontal
-          pagingEnabled
-          scrollEventThrottle={16}
-          showsHorizontalScrollIndicator={false}
-          onScroll={handleScroll}
-          snapToInterval={windowWidth}
-          snapToAlignment="center"
-          contentContainerStyle={{ flexDirection: 'row' }}
-        >
-          {filteredDrinks.length > 0 ? (
+  };
+
+  // Add drinks to history when drinks are loaded (not when filtered)
+  useEffect(() => {
+    if (drinks.length > 0 && !processedMessages.has(messageIndex)) {
+      addDrinksToHistory();
+    }
+  }, [drinks, messageIndex]);
+
+  // Horizontal Scroll View
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        ref={scrollViewRef}
+        horizontal
+        pagingEnabled
+        scrollEventThrottle={16}
+        showsHorizontalScrollIndicator={false}
+        onScroll={handleScroll}
+        snapToInterval={windowWidth}
+        snapToAlignment="center"
+        contentContainerStyle={{ flexDirection: "row" }}
+      >
+        {filteredDrinks.length > 0 ? (
           [
             ...filteredDrinks.slice(0, 2).map((drink: Drink, index: number) => (
               <View key={drink.name || index} style={styles.drinkContainer}>
-                <DrinkView 
-                    name={drink.name}
-                    image={drink.image_description && drink.image_description.startsWith('http') ? {uri: drink.image_description} : null}
-                    ingredients={drink.ingredients || []}
-                    description={drink.description || ""}
-                  />
+                <DrinkView
+                  name={drink.name}
+                  image={
+                    drink.image_description &&
+                    drink.image_description.startsWith("http")
+                      ? { uri: drink.image_description }
+                      : null
+                  }
+                  ingredients={drink.ingredients || []}
+                  description={drink.description || ""}
+                />
               </View>
             )),
             <View key="recommend" style={styles.drinkContainer}>
-                <RecommendDrinkView />
-            </View>
+              <RecommendDrinkView />
+            </View>,
           ]
-          ) : (
-            <View key="recommend" style={styles.drinkContainer}>
-                <RecommendDrinkView />
-            </View>
-          )}
-        </ScrollView>
-        <View style={styles.pagination}>
+        ) : (
+          <View key="recommend" style={styles.drinkContainer}>
+            <RecommendDrinkView />
+          </View>
+        )}
+      </ScrollView>
+      <View style={styles.pagination}>
         {/* Pagination Dots */}
         {filteredDrinks.length === 0 ? (
-          <View 
-            style={[
-              styles.paginationDot,
-              styles.paginationDotActive
-            ]}
-          />
+          <View style={[styles.paginationDot, styles.paginationDotActive]} />
         ) : (
-          Array.from({ length: Math.min(filteredDrinks.length, 2) + 1 }, (_, index) => (
-            <View 
-              key={index}
-              style={[
-                styles.paginationDot,
-                index === currentMessagePage && styles.paginationDotActive
-              ]}
-          />
-        ))
+          Array.from(
+            { length: Math.min(filteredDrinks.length, 2) + 1 },
+            (_, index) => (
+              <View
+                key={index}
+                style={[
+                  styles.paginationDot,
+                  index === currentMessagePage && styles.paginationDotActive,
+                ]}
+              />
+            ),
+          )
         )}
       </View>
-      {/* <DrinkInfoChatBox /> */}
-      </View>
-    );
-}
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "#f5f5f5",
     marginTop: 16,
   },
   drinkContainer: {
-    width: Dimensions.get('window').width - 20,
+    width: Dimensions.get("window").width - 20,
   },
   pagination: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
     marginTop: 10,
   },
   paginationDot: {
     width: 14,
     height: 6,
     borderRadius: 4,
-    backgroundColor: '#ccc',
+    backgroundColor: "#ccc",
     marginHorizontal: 2,
   },
   paginationDotActive: {
-    backgroundColor: '#000000ff', 
+    backgroundColor: "#000000ff",
     width: 22,
   },
-})
+});

--- a/app/screens/drink-chat-screen.tsx
+++ b/app/screens/drink-chat-screen.tsx
@@ -1,16 +1,35 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
 import React, { useEffect, useRef, useState } from "react";
-import { Dimensions, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Dimensions,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View
+} from "react-native";
+import FlaskAndGlassSVG from "../../assets/svgs/flask-and-glass-svg";
 import { ChatBoxText } from "../components/chat-box-text/chat-box-text";
-import { DrinkInfoCard, englishToPolishPower, englishToPolishTaste } from "../components/drink-info-card/drink-info-card";
+import {
+  DrinkInfoCard,
+  englishToPolishPower,
+  englishToPolishTaste,
+} from "../components/drink-info-card/drink-info-card";
 import { DrinksCarousel } from "../components/drinks-carousel/drinks-carousel";
 import ErrorDisplay from "../components/error-display/error-display";
 import InputBoxWithSuggestions from "../components/input-box-with-suggestions";
 
 export default function DrinkChatScreen() {
+  const router = useRouter();
   const [messages, setMessages] = useState<string[]>([]);
-  const [messageFilters, setMessageFilters] = useState<{ flavorProfile: string, power: string }[]>([]);
+  const [messageFilters, setMessageFilters] = useState<
+    { flavorProfile: string; power: string }[]
+  >([]);
   const [message, setMessage] = useState<string>("");
-  const [filters, setFilters] = useState({ flavorProfile: "sweet", power: "weak" });
+  const [filters, setFilters] = useState({
+    flavorProfile: "sweet",
+    power: "weak",
+  });
   const [failedMessages, setFailedMessages] = useState<Set<number>>(new Set());
   const [isLoading, setIsLoading] = useState(false);
   const [currentError, setCurrentError] = useState<string | null>(null);
@@ -19,11 +38,11 @@ export default function DrinkChatScreen() {
   // Handle on History Press
   const handleHistoryPress = (msg: string) => {
     setMessage(msg);
-  }
+  };
 
   // Handle Error Display
   const handleError = (errorMessage: string) => {
-    console.log('Error received:', errorMessage); // Debug log
+    console.log("Error received:", errorMessage); // Debug log
     setCurrentError(errorMessage);
   };
 
@@ -32,13 +51,13 @@ export default function DrinkChatScreen() {
   };
 
   const handleRetryMessage = (index: number) => {
-    setFailedMessages(prev => {
+    setFailedMessages((prev) => {
       const newSet = new Set(prev);
       newSet.delete(index);
       return newSet;
     });
     setCurrentError(null);
-  }
+  };
 
   // Input Validation
   const validateInput = (text: string): boolean => {
@@ -46,7 +65,7 @@ export default function DrinkChatScreen() {
     if (text.trim().length < 3) return false;
     if (text.trim().length > 500) return false;
     return true;
-  }
+  };
 
   // Handle Message Change
   const handleMessageChange = (message: string) => {
@@ -54,10 +73,14 @@ export default function DrinkChatScreen() {
   };
 
   // Handle Filter Change
-  const handleFilterChange = (filterData: { drinkOptions: string[], power: string, flavorProfile: string }) => {
+  const handleFilterChange = (filterData: {
+    drinkOptions: string[];
+    power: string;
+    flavorProfile: string;
+  }) => {
     setFilters({
       flavorProfile: filterData.flavorProfile,
-      power: filterData.power
+      power: filterData.power,
     });
   };
 
@@ -74,14 +97,13 @@ export default function DrinkChatScreen() {
       setMessages([...messages, message]);
       setMessageFilters([...messageFilters, filters]);
       setMessage("");
-
     } catch (error) {
-      console.error('Failed to send message:', error);
-      setFailedMessages(prev => new Set(prev).add(messageIndex));
+      console.error("Failed to send message:", error);
+      setFailedMessages((prev) => new Set(prev).add(messageIndex));
     } finally {
       setIsLoading(false);
     }
-  }
+  };
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -94,30 +116,51 @@ export default function DrinkChatScreen() {
 
   return (
     <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.navHistoryButton}
+        onPress={() => router.push("/screens/favorites-history-screen")}
+      >
+        <Ionicons name="time-outline" size={24} color="white" />
+      </TouchableOpacity>
+
       <ScrollView
         ref={scrollViewRef}
         style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
+        contentContainerStyle={[
+          styles.scrollContent,
+          messages.length === 0 && styles.emptyScrollContent,
+        ]}
       >
-        {messages.map((msg, index) => (
-          <View key={index} style={styles.messageContainer}>
-            <ChatBoxText
-              message={msg}
-              onHistoryPress={() => handleHistoryPress(msg)}
-              onRetryPress={() => handleRetryMessage(index)}
-              hasError={failedMessages.has(index)}
-            />
-            <DrinksCarousel
-              message={msg}
-              messageIndex={index}
-              filters={{
-                flavorProfile: englishToPolishTaste(messageFilters[index]?.flavorProfile || filters.flavorProfile),
-                power: englishToPolishPower(messageFilters[index]?.power || filters.power)
-              }}
-              onError={handleError}
-            />
+        {messages.length === 0 ? (
+          <View style={styles.emptyStateContainer}>
+            <FlaskAndGlassSVG />
           </View>
-        ))}
+        ) : (
+          messages.map((msg, index) => (
+            <View key={index} style={styles.messageContainer}>
+              <ChatBoxText
+                message={msg}
+                onHistoryPress={() => handleHistoryPress(msg)}
+                onRetryPress={() => handleRetryMessage(index)}
+                hasError={failedMessages.has(index)}
+              />
+              <DrinksCarousel
+                message={msg}
+                messageIndex={index}
+                filters={{
+                  flavorProfile: englishToPolishTaste(
+                    messageFilters[index]?.flavorProfile ||
+                      filters.flavorProfile,
+                  ),
+                  power: englishToPolishPower(
+                    messageFilters[index]?.power || filters.power,
+                  ),
+                }}
+                onError={handleError}
+              />
+            </View>
+          ))
+        )}
       </ScrollView>
 
       {/* Fixed Drink Info Card above Input */}
@@ -154,7 +197,7 @@ export default function DrinkChatScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "rgba(235, 231, 230, 1)",
   },
   scrollView: {
     flex: 1,
@@ -162,22 +205,51 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     flexGrow: 1,
-    justifyContent: 'flex-end',
+    justifyContent: "flex-end",
     paddingBottom: 350,
   },
+  emptyScrollContent: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  emptyStateContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 80,
+  },
+  emptyStateText: {
+    marginTop: 24,
+    fontSize: 14,
+    color: "#333",
+    textAlign: "center",
+    lineHeight: 20,
+    fontWeight: "400",
+  },
+  navHistoryButton: {
+    position: "absolute",
+    top: 50,
+    right: 20,
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    backgroundColor: "#000",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 10,
+  },
   drinkContainer: {
-    width: Dimensions.get('window').width,
+    width: Dimensions.get("window").width,
   },
   messageContainer: {
     paddingTop: 16,
-    paddingHorizontal: 8
+    paddingHorizontal: 8,
   },
   fixedBottomSection: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "rgba(235, 231, 230, 1)",
     shadowColor: "#000",
     shadowOffset: {
       width: 0,

--- a/app/screens/drink-chat-screen.tsx
+++ b/app/screens/drink-chat-screen.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useEffect, useRef, useState } from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Dimensions,
   ScrollView,
@@ -21,6 +22,7 @@ import InputBoxWithSuggestions from "../components/input-box-with-suggestions";
 
 export default function DrinkChatScreen() {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const [messages, setMessages] = useState<string[]>([]);
   const [messageFilters, setMessageFilters] = useState<
     { flavorProfile: string; power: string }[]
@@ -117,8 +119,10 @@ export default function DrinkChatScreen() {
   return (
     <View style={styles.container}>
       <TouchableOpacity
-        style={styles.navHistoryButton}
+        style={[styles.navHistoryButton, { top: insets.top + 8 }]}
         onPress={() => router.push("/screens/favorites-history-screen")}
+        accessibilityRole="button"
+        accessibilityLabel="View drink history"
       >
         <Ionicons name="time-outline" size={24} color="white" />
       </TouchableOpacity>
@@ -227,7 +231,6 @@ const styles = StyleSheet.create({
   },
   navHistoryButton: {
     position: "absolute",
-    top: 50,
     right: 20,
     width: 44,
     height: 44,


### PR DESCRIPTION
The history navigation button in `DrinkChatScreen` used a hard-coded `top: 50` offset, causing overlap with the status bar/notch on devices with safe-area insets. It also lacked accessibility metadata.

## Changes

- **Safe-area positioning**: Import `useSafeAreaInsets` and replace static `top: 50` with `insets.top + 8` applied as an inline style override, matching the pattern used in `favorites-history-screen`.
- **Accessibility**: Add `accessibilityRole="button"` and `accessibilityLabel="View drink history"` to the `TouchableOpacity`.

```tsx
const insets = useSafeAreaInsets();
// ...
<TouchableOpacity
  style={[styles.navHistoryButton, { top: insets.top + 8 }]}
  onPress={() => router.push("/screens/favorites-history-screen")}
  accessibilityRole="button"
  accessibilityLabel="View drink history"
>
```